### PR TITLE
Update GitHub Actions workflow and README for daily.dev integration

### DIFF
--- a/.github/workflows/activity-update.yml
+++ b/.github/workflows/activity-update.yml
@@ -4,7 +4,7 @@ on:
     - cron: "*/30 * * * *"
   workflow_dispatch:
 jobs:
-  build:
+  github-activity-update:
     name: Update this repo's README with recent activity
     runs-on: ubuntu-latest
     permissions:
@@ -15,13 +15,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.METRICS_TOKEN }}
 
-  devcard:
+  devcard-update:
     name: Update daily.dev stats
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - name: devcard
-        uses: dailydotdev/action-devcard@2.0.2
+        uses: dailydotdev/action-devcard@3.0.0
         with:
-          devcard_id: ${{ secrets.DEVCARD_ID }}
+          user_id: ${{ secrets.DEVCARD_ID }}
+          commit_message: "chore: update ${filename}"

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@
 
 ### 👨‍💻 Daily.dev
 
-<a href="https://app.daily.dev/srajasimman"><img src="https://github.com/srajasimman/srajasimman/blob/master/devcard.svg" width="350" alt="Rajasimman S's Dev Card"/></a>
+<a href="https://app.daily.dev/srajasimman"><img src="./devcard.png" width="356" alt="Rajasimman S's Dev Card"/></a>
 
 <img src="https://user-images.githubusercontent.com/73097560/115834477-dbab4500-a447-11eb-908a-139a6edaec5c.gif">
 


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow and a minor change to the `README.md` file. The changes aim to improve the automation process for updating the repository's README with recent activity and daily.dev stats.

Updates to GitHub Actions workflow:

* [`.github/workflows/activity-update.yml`](diffhunk://#diff-653ab8afc1d59e0a1829c762725a3edba9235bb915af3592115b23ae366f4409L7-R7): Renamed the `build` job to `github-activity-update` to better reflect its purpose.
* [`.github/workflows/activity-update.yml`](diffhunk://#diff-653ab8afc1d59e0a1829c762725a3edba9235bb915af3592115b23ae366f4409L18-R28): Renamed the `devcard` job to `devcard-update` and updated the action to use version `3.0.0` with a new parameter `commit_message`.

Minor update to `README.md`:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L76-R76): Changed the image source for the daily.dev card from an external URL to a local file `devcard.png`.